### PR TITLE
index,showアクションを追加

### DIFF
--- a/rails/app/controllers/api/v1/cards_controller.rb
+++ b/rails/app/controllers/api/v1/cards_controller.rb
@@ -1,0 +1,22 @@
+# エイリアス経由!
+class Api::V1::CardsController < Api::V1::BaseController
+  before_action :authenticate_user! # ログインユーザーのみ
+
+  # Get /api/v1/cards 一覧取得
+  def index
+    cards = current_user.cards.order(logged_date: :desc)
+    render json: serialize(cards), status: :ok
+  end
+
+  # Get /api/v1/cards/:id 詳細取得
+  def show
+    card = current_user.cards.find(params[:id])
+    render json: serialize(card), status: :ok
+  end
+
+  private
+
+    def serialize(resource)
+      resource.as_json(only: %i[id content logged_date])
+    end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       namespace :current do
         resource :user, only: [:show]
       end
+      resources :cards, only: [:index, :show, :create, :update, :destroy]
     end
   end
 end

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -7,3 +7,18 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+# === ゲストユーザーシード ===
+guest = User.find_or_create_by!(email: "test1@example.com") do |u|
+  u.name                  = "テスト太郎"
+  u.password              = "password"
+  u.password_confirmation = "password"
+  u.confirmed_at          = Time.current
+end
+
+# === ThanksCard のサンプルデータ ===
+5.times do |i|
+  logged_date = Time.zone.today - i.days
+  guest.cards.find_or_create_by!(logged_date: logged_date) do |card|
+    card.content = "サンプル感謝 #{i + 1}"
+  end
+end

--- a/rails/spec/rails_helper.rb
+++ b/rails/spec/rails_helper.rb
@@ -32,10 +32,17 @@ begin
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+
+# supportディレクトリ内のファイルの読み込み
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+
 RSpec.configure do |config|
   # FactoryBotの宣言を省略
   config.include FactoryBot::Syntax::Methods
-  
+
+  #認証用ヘッダーをまとめる(認証済みのユーザーが持つaccess-token,uid,client)
+  config.include AuthHelpers, type: :request
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/rails/spec/requests/api/v1/cards_spec.rb
+++ b/rails/spec/requests/api/v1/cards_spec.rb
@@ -1,7 +1,53 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Cards", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user)   { create(:user, confirmed_at: Time.current) }
+  let!(:cards) { create_list(:card, 3, user: user) } # テスト前に必ず実行 作成した3件分のレコードオブジェクトを要素に持つ配列
+
+  describe "GET /api/v1/cards" do
+    context "認証あり" do
+      let(:headers) { auth_headers_for(user).merge("Content-Type" => "application/json") }
+
+      it "200 が返り、カードの配列を返す" do
+        get "/api/v1/cards", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body) # JSONをハッシュに変換(本来は自動)
+        expect(json.size).to eq 3
+        expect(json.first).to include("id", "content", "logged_date")
+      end
+    end
+
+    context "認証なし" do
+      it "401 Unauthorized が返る" do
+        get "/api/v1/cards"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/cards/:id" do
+    let(:card) { cards.first }
+
+    context "認証あり" do
+      let(:headers) { auth_headers_for(user).merge("Content-Type" => "application/json") }
+
+      it "200 が返り、カードオブジェクトを返す" do
+        get "/api/v1/cards/#{card.id}", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json).to include(
+          "id" => card.id,
+          "content" => card.content,
+          "logged_date" => card.logged_date.to_s, # 日付オブジェクトを文字列に変換
+        )
+      end
+    end
+
+    context "認証なし" do
+      it "401 Unauthorized が返る" do
+        get "/api/v1/cards/#{card.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 end

--- a/rails/spec/requests/api/v1/cards_spec.rb
+++ b/rails/spec/requests/api/v1/cards_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Cards", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/rails/spec/support/auth_helpers.rb
+++ b/rails/spec/support/auth_helpers.rb
@@ -1,0 +1,14 @@
+module AuthHelpers
+  # メソッド定義
+  def auth_headers_for(user)
+    post "/api/v1/auth/sign_in", # PostはRequest Spec が提供しているメソッドを呼び出している
+         params: { email: user.email, password: user.password }.to_json,
+         headers: { "Content-Type" => "application/json" }
+
+    {
+      "access-token" => response.headers["access-token"],
+      "client" => response.headers["client"],
+      "uid" => response.headers["uid"],
+    }
+  end
+end


### PR DESCRIPTION
N＋1問題の対策は今のところ必要ない
```
def index
current_user.cards.order(logged_date: :desc)
```
SQL 1 回で cards テーブル から必要なレコードをすべて取得するだけなので、N+1 問題は発生しない
```
def show
current_user.cards.find(params[:id])
```
こちらも単一レコードを主キーで取得するため、追加クエリは発生しません。

**もしカード一覧の JSON に ユーザー名 や コメント数 などを含めるなら、includes(:user) や includes(:comments) を使って事前ロードを検討**